### PR TITLE
Adds custom_methods to RestUp via options

### DIFF
--- a/lib/restup.js
+++ b/lib/restup.js
@@ -5,8 +5,8 @@
  */
 
 var _       = require('underscore'),
-	METHODS = require('./utils').METHODS,
-	Q       = require('q')
+    METHODS = require('./utils').METHODS,
+    Q       = require('q')
 ;
 
 var RestUp = function (options, parent) {
@@ -48,12 +48,13 @@ var RestUp = function (options, parent) {
 				parent.api[self.resource_name] = resource;
 				return parent;
 			}
-			return resource; // return user api?
+			return resource;
 		},
 		api: {}
 	};
 
-	_.each(METHODS, function (method) {
+	// denodeify core methods and custom methods
+	_.each(_.compact(_.union(METHODS, options.custom_methods)), function (method) {
 		self[method] = function (handler) {
 			self.api[method] = Q.denodeify(handler);
 			return self;


### PR DESCRIPTION
@RasterBurn this is simple implementation allows custom methods to be added to resource apis. Here's a simple example:

```
var model = require('model'),
    api = restUp({
        custom_methods: ['search']
    })
    .resource('users')
        .get(model.getUser)
        .post(model.addUser)
        .put(model.updateUser)
        .delete(model.deleteUser)
        .search(model.searchUser)
    .end();

var myQuery = {...};
api().users().search(myQuery);
```
